### PR TITLE
Use standard linux image instead of Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.1-alpine
+FROM golang:1.7
 MAINTAINER hteen <i@hteen.cn>
 
 RUN apk add --no-cache git make openssl


### PR DESCRIPTION
Because alpine does not use `glibc`.  The binary built in alpine cannot be used in other Linux system.

See http://www.blang.io/posts/2015-04_golang-alpine-build-golang-binaries-for-alpine-linux/  limitations.